### PR TITLE
Upgrade Graph dependencies to v0.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy-local": "graph deploy --node http://127.0.0.1:8020 --ipfs http://localhost:5001 asselstine/pooltogether subgraph.local.yaml"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "^0.15.0",
-    "@graphprotocol/graph-ts": "^0.15.1"
+    "@graphprotocol/graph-cli": "^0.16.0",
+    "@graphprotocol/graph-ts": "^0.16.0"
   }
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -6,21 +6,21 @@ enum DrawState {
 
 type Draw @entity {
   id: ID!
-  drawId: BigInt!
-  feeBeneficiary: Bytes!
-  secretHash: Bytes!
-  feeFraction: BigInt!
-  winner: Bytes!
-  entropy: Bytes!
-  winnings: BigInt!
-  fee: BigInt!
-  state: DrawState!
+  drawId: BigInt
+  feeBeneficiary: Bytes
+  secretHash: Bytes
+  feeFraction: BigInt
+  winner: Bytes
+  entropy: Bytes
+  winnings: BigInt
+  fee: BigInt
+  state: DrawState
 
-  openedAt: BigInt!
-  committedAt: BigInt!
-  rewardedAt: BigInt!
+  openedAt: BigInt
+  committedAt: BigInt
+  rewardedAt: BigInt
 
-  balance: BigInt!
+  balance: BigInt
 
   entries: [PlayerEntry!] @derivedFrom(field: "draw")
 }
@@ -44,5 +44,5 @@ type PlayerEntry @entity {
   draw: Draw!
   player: Player!
   balance: BigInt!
-  sponsorshipBalance: BigInt!
+  sponsorshipBalance: BigInt
 }

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -179,7 +179,7 @@ export function handleRewarded(event: Rewarded): void {
 
   const pool = Pool.bind(event.address)
   const committedDrawId = pool.currentCommittedDrawId()
-  const playerEntry = createPlayerEntry(event.params.winner.toString(), committedDrawId)
+  const playerEntry = createPlayerEntry(event.params.winner.toHexString(), committedDrawId)
   playerEntry.balance = pool.committedBalanceOf(event.params.winner)
   playerEntry.save()
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,10 +9,10 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@graphprotocol/graph-cli@^0.15.0":
-  version "0.15.3"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-cli/-/graph-cli-0.15.3.tgz#be127af1e3c6c138553b63de772a4e9c2209b55a"
-  integrity sha512-z/In/CiWpA4Ug73hEHMhssL7cbchI3MnZNBJ3lYf4qkRURLASVaDM9vLSMyRU5wrVw8JdANoij8xKG2e8v+29g==
+"@graphprotocol/graph-cli@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-cli/-/graph-cli-0.16.0.tgz#0829a42a2ec4c122fbdb8bfb482b74e0d27db935"
+  integrity sha512-tTpJc9waeRPzhF/aeWxu4jGW7GonVTQBeubTGVC6B2oFHpADXrQdthPgpmtThexXGHk46q14bHLuiSEm6ZBpkw==
   dependencies:
     assemblyscript "https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3"
     chalk "^2.4.1"
@@ -34,10 +34,10 @@
   optionalDependencies:
     keytar "^4.6.0"
 
-"@graphprotocol/graph-ts@^0.15.1":
-  version "0.15.1"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.15.1.tgz#d6cc85197e45dda9bb4083654c183470ff23333e"
-  integrity sha512-l5veH44ULpKq1kLudbfJctgxLaLpnLnYiDIIZn+N8UC1SrpqjLhJyRMfm+uH4xTglmAwI74wyynKWktXp44/iw==
+"@graphprotocol/graph-ts@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.16.0.tgz#a6f5e8a39b7d651887c80bb2422cfb3a0fbf55d7"
+  integrity sha512-zDhlIYlzE0xq5cJkF6fGwshfPR2z6rRZetNCgEclAtDv1uPSQaPQJuiIWL2hpTMjYHLX2OSNxy8F1G69jC708A==
   dependencies:
     assemblyscript "https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3"
 
@@ -193,17 +193,6 @@ asn1@~0.2.3:
 "assemblyscript@git+https://github.com/AssemblyScript/assemblyscript.git#36040d5b5312f19a025782b5e36663823494c2f3":
   version "0.6.0"
   resolved "git+https://github.com/AssemblyScript/assemblyscript.git#36040d5b5312f19a025782b5e36663823494c2f3"
-  dependencies:
-    "@protobufjs/utf8" "^1.1.0"
-    binaryen "77.0.0-nightly.20190407"
-    glob "^7.1.3"
-    long "^4.0.0"
-    opencollective-postinstall "^2.0.0"
-    source-map-support "^0.5.11"
-
-"assemblyscript@https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3":
-  version "0.6.0"
-  resolved "https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3"
   dependencies:
     "@protobufjs/utf8" "^1.1.0"
     binaryen "77.0.0-nightly.20190407"


### PR DESCRIPTION
With release v0.16.0 of `graph-ts`, `graph-cli`, and `graph-node` changes have been made that could lead to new errors if you redeploy the subgraph. Subgraph entities are validated more strictly than in the past, particularly with respect to  non-null type entity fields.  

This PR makes a few necessary changes to work with the stricter validation on non-null entity fields.

Note: v0.16.0 of `graph-node` will be rolled out to the [hosted-service](https://www.thegraph.com/explorer) later today (November 5th, 2019.)